### PR TITLE
feat: support config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,18 @@ for `tslint@5.2.0+`
 
 ## Options
 
-Same as [Prettier Options](https://github.com/prettier/prettier#options), for example:
+If there is no option provided, it'll try to load [config file](https://github.com/prettier/prettier#configuration-file) as possible, uses Prettier's default option if not found.
+
+```json
+{
+  "extends": ["tslint-plugin-prettier"],
+  "rules": {
+    "prettier": true
+  }
+}
+```
+
+If you'd like to specify options manually, just put [Prettier Options](https://github.com/prettier/prettier#options) in the second argument, for example:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ for `tslint@5.2.0+`
 
 ## Options
 
-If there is no option provided, it'll try to load [config file](https://github.com/prettier/prettier#configuration-file) if possible (require `prettier@1.6.x+`), uses Prettier's default option if not found.
+If there is no option provided, it'll try to load [config file](https://github.com/prettier/prettier#configuration-file) if possible (require `prettier@1.7.0+`), uses Prettier's default option if not found.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ for `tslint@5.2.0+`
 
 ## Options
 
-If there is no option provided, it'll try to load [config file](https://github.com/prettier/prettier#configuration-file) as possible, uses Prettier's default option if not found.
+If there is no option provided, it'll try to load [config file](https://github.com/prettier/prettier#configuration-file) if possible (require `prettier@1.6.x+`), uses Prettier's default option if not found.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/node": "8.0.26",
     "@types/prettier": "1.6.0",
     "nyc": "11.1.0",
-    "prettier": "1.6.1",
+    "prettier": "ikatyang/prettier#50cfbf7",
     "prettier-config-ikatyang": "1.1.1",
     "standard-version": "4.2.0",
     "tslint": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/node": "8.0.26",
     "@types/prettier": "1.6.0",
     "nyc": "11.1.0",
-    "prettier": "ikatyang/prettier#50cfbf7",
+    "prettier": "ikatyang/prettier#test-deps",
     "prettier-config-ikatyang": "1.1.1",
     "standard-version": "4.2.0",
     "tslint": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/node": "8.0.26",
     "@types/prettier": "1.6.0",
     "nyc": "11.1.0",
-    "prettier": "ikatyang/prettier#test-deps",
+    "prettier": "ikatyang/prettier#feat/resolve-config-sync",
     "prettier-config-ikatyang": "1.1.1",
     "standard-version": "4.2.0",
     "tslint": "5.7.0",

--- a/src/prettierRule.ts
+++ b/src/prettierRule.ts
@@ -1,3 +1,4 @@
+import assert = require('assert');
 import * as utils from 'eslint-plugin-prettier';
 import * as prettier from 'prettier';
 import * as tslint from 'tslint';
@@ -14,7 +15,7 @@ declare module 'prettier' {
 }
 // tslint:enable:naming-convention
 
-// tslint:disable:max-classes-per-file no-use-before-declare restrict-plus-operands
+// tslint:disable:max-classes-per-file no-use-before-declare
 
 export class Rule extends tslint.Rules.AbstractRule {
   public apply(source_file: ts.SourceFile): tslint.RuleFailure[] {
@@ -35,6 +36,15 @@ class Walker extends tslint.AbstractWalker<any[]> {
         options = rule_argument_1 as prettier.Options;
         break;
       default:
+        try {
+          // tslint:disable-next-line:strict-type-predicates
+          assert(typeof prettier.resolveConfig.sync === 'function');
+        } catch {
+          // backward compatibility: use default options if no resolveConfig.sync()
+          // istanbul ignore next
+          break;
+        }
+
         const resolved_config = prettier.resolveConfig.sync(
           source_file.fileName,
         );

--- a/src/prettierRule.ts
+++ b/src/prettierRule.ts
@@ -5,13 +5,12 @@ import * as ts from 'typescript';
 
 // tslint:disable:naming-convention
 declare module 'prettier' {
-  interface ResolveConfigOptions {
-    sync?: boolean;
+  export namespace resolveConfig {
+    function sync(
+      filePath?: string,
+      options?: ResolveConfigOptions,
+    ): null | Options;
   }
-  export function resolveConfig(
-    filePath: string | undefined,
-    options: ResolveConfigOptions & { sync: true },
-  ): null | Options;
 }
 // tslint:enable:naming-convention
 
@@ -36,9 +35,9 @@ class Walker extends tslint.AbstractWalker<any[]> {
         options = rule_argument_1 as prettier.Options;
         break;
       default:
-        const resolved_config = prettier.resolveConfig(source_file.fileName, {
-          sync: true,
-        });
+        const resolved_config = prettier.resolveConfig.sync(
+          source_file.fileName,
+        );
         if (resolved_config !== null) {
           options = resolved_config;
         }

--- a/src/prettierRule.ts
+++ b/src/prettierRule.ts
@@ -4,17 +4,6 @@ import * as prettier from 'prettier';
 import * as tslint from 'tslint';
 import * as ts from 'typescript';
 
-// tslint:disable:naming-convention
-declare module 'prettier' {
-  export namespace resolveConfig {
-    function sync(
-      filePath?: string,
-      options?: ResolveConfigOptions,
-    ): null | Options;
-  }
-}
-// tslint:enable:naming-convention
-
 // tslint:disable:max-classes-per-file no-use-before-declare
 
 export class Rule extends tslint.Rules.AbstractRule {

--- a/tests/prettier/config-file-not-found/test.ts.lint
+++ b/tests/prettier/config-file-not-found/test.ts.lint
@@ -1,0 +1,2 @@
+var foo ="";
+         ~ [Insert `·`]

--- a/tests/prettier/config-file-not-found/tslint.json
+++ b/tests/prettier/config-file-not-found/tslint.json
@@ -1,6 +1,6 @@
 {
   "rulesDirectory": ["../../../rules"],
   "rules": {
-    "prettier": [true, {}]
+    "prettier": true
   }
 }

--- a/tests/prettier/config-file-override/.prettierrc
+++ b/tests/prettier/config-file-override/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "overrides": [{
+    "files": "doubleQuote.ts",
+    "options": {
+      "singleQuote": false
+    }
+  }]
+}

--- a/tests/prettier/config-file-override/doubleQuote.ts.lint
+++ b/tests/prettier/config-file-override/doubleQuote.ts.lint
@@ -1,0 +1,2 @@
+var foo ="";
+         ~ [Insert `·`]

--- a/tests/prettier/config-file-override/singleQuote.ts.lint
+++ b/tests/prettier/config-file-override/singleQuote.ts.lint
@@ -1,0 +1,2 @@
+var foo ="";
+         ~~ [Replace `""` with `·''`]

--- a/tests/prettier/config-file-override/tslint.json
+++ b/tests/prettier/config-file-override/tslint.json
@@ -1,6 +1,6 @@
 {
   "rulesDirectory": ["../../../rules"],
   "rules": {
-    "prettier": [true, {}]
+    "prettier": true
   }
 }

--- a/tests/prettier/config-file-simple/.prettierrc
+++ b/tests/prettier/config-file-simple/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/tests/prettier/config-file-simple/test.ts.lint
+++ b/tests/prettier/config-file-simple/test.ts.lint
@@ -1,0 +1,2 @@
+var foo ="";
+         ~~ [Replace `""` with `·''`]

--- a/tests/prettier/config-file-simple/tslint.json
+++ b/tests/prettier/config-file-simple/tslint.json
@@ -1,6 +1,6 @@
 {
   "rulesDirectory": ["../../../rules"],
   "rules": {
-    "prettier": [true, {}]
+    "prettier": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,9 +509,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cosmiconfig@git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3":
+cosmiconfig@davidtheclark/cosmiconfig#3.0:
   version "2.2.2"
-  resolved "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3"
+  resolved "https://codeload.github.com/davidtheclark/cosmiconfig/tar.gz/12239b263684a7268883eccb30714446e105ff95"
   dependencies:
     is-directory "^0.3.1"
     is-promise "^2.1.0"
@@ -1607,14 +1607,14 @@ prettier-config-ikatyang@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/prettier-config-ikatyang/-/prettier-config-ikatyang-1.1.1.tgz#9ccab4bc2d441e4c68b58dbe8f1a4e18213c3f2d"
 
-prettier@ikatyang/prettier#50cfbf7:
+prettier@ikatyang/prettier#test-deps:
   version "1.6.1"
-  resolved "https://codeload.github.com/ikatyang/prettier/tar.gz/50cfbf7"
+  resolved "https://codeload.github.com/ikatyang/prettier/tar.gz/1cde07cd1c9e8ddb84dbcde2bafd3bcf5741b5aa"
   dependencies:
     babel-code-frame "7.0.0-alpha.12"
     babylon "7.0.0-beta.22"
     chalk "2.0.1"
-    cosmiconfig "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3"
+    cosmiconfig davidtheclark/cosmiconfig#3.0
     dashify "0.2.2"
     diff "3.2.0"
     esutils "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,10 @@
   version "8.0.26"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.26.tgz#4d58be925306fd22b1141085535a0268b8beb189"
 
+"@types/node@^6.0.46":
+  version "6.0.88"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
+
 "@types/prettier@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.6.0.tgz#81db8cd7cd2be1d75fdbe9ec306f3f7edab4476c"
@@ -39,7 +43,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-regex@^2.0.0:
+ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -51,6 +55,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
@@ -60,6 +70,12 @@ append-transform@^0.4.0:
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+
+argparse@^1.0.7:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  dependencies:
+    sprintf-js "~1.0.2"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -79,6 +95,16 @@ array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
 
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -90,6 +116,14 @@ arrify@^1.0.1:
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
+babel-code-frame@7.0.0-alpha.12:
+  version "7.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-alpha.12.tgz#26fbb2eab1c20763271fecb6b04a108756fae61f"
+  dependencies:
+    chalk "^1.1.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -158,6 +192,10 @@ babel-types@^6.18.0, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
+babylon@7.0.0-beta.22:
+  version "7.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.22.tgz#74f0ad82ed7c7c3cfeab74cf684f815104161b65"
+
 babylon@^6.17.4, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
@@ -223,7 +261,15 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.3:
+chalk@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chalk@^1.1.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -232,6 +278,14 @@ chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -252,6 +306,16 @@ cliui@^3.2.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+color-convert@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 colors@^1.1.2:
   version "1.1.2"
@@ -445,6 +509,19 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+"cosmiconfig@git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3":
+  version "2.2.2"
+  resolved "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3"
+  dependencies:
+    is-directory "^0.3.1"
+    is-promise "^2.1.0"
+    js-yaml "^3.9.0"
+    minimist "^1.2.0"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    please-upgrade-node "^3.0.1"
+    require-from-string "^1.1.0"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -471,6 +548,10 @@ dargs@^4.0.1:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
   dependencies:
     number-is-nan "^1.0.0"
+
+dashify@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dashify/-/dashify-0.2.2.tgz#6a07415a01c91faf4a32e38d9dfba71f61cb20fe"
 
 dateformat@^1.0.11, dateformat@^1.0.12:
   version "1.0.12"
@@ -504,6 +585,10 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@^3.2.0:
   version "3.3.0"
@@ -539,13 +624,17 @@ eslint-plugin-prettier@^2.2.0:
     fast-diff "^1.1.1"
     jest-docblock "^20.0.1"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esutils@2.0.2, esutils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
 esutils@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
-
-esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -623,6 +712,14 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+flatten@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+flow-parser@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.51.0.tgz#e1c0ceb6f802ba21d16c2fda8e42c824f40f4684"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -668,7 +765,7 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
-get-stream@^3.0.0:
+get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
@@ -719,7 +816,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
+glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -734,9 +831,25 @@ globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graphql@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.1.tgz#75c93c2ce73aeb5bae2eefb555a8e9e39c36027d"
+  dependencies:
+    iterall "^1.1.0"
 
 handlebars@^4.0.2, handlebars@^4.0.3:
   version "4.0.10"
@@ -758,9 +871,17 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+
+ignore@^3.3.3:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -771,6 +892,10 @@ indent-string@^2.1.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
   dependencies:
     repeating "^2.0.0"
+
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -810,6 +935,10 @@ is-builtin-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -874,6 +1003,10 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -958,13 +1091,44 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
+iterall@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
+
 jest-docblock@^20.0.1:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
+jest-matcher-utils@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^20.0.3"
+
+jest-validate@20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-20.0.3.tgz#d0cfd1de4f579f298484925c280f8f1d94ec3cab"
+  dependencies:
+    chalk "^1.1.3"
+    jest-matcher-utils "^20.0.3"
+    leven "^2.1.0"
+    pretty-format "^20.0.3"
+
+js-base64@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+js-yaml@^3.9.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -999,6 +1163,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -1054,6 +1222,10 @@ lodash.templatesettings@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
   dependencies:
     lodash._reinterpolate "~3.0.0"
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
 lodash.upperfirst@^4.3.1:
   version "4.3.1"
@@ -1150,7 +1322,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1160,7 +1332,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3:
+minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1312,6 +1484,12 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse5@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
+  dependencies:
+    "@types/node" "^6.0.46"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -1368,6 +1546,59 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+please-upgrade-node@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
+
+postcss-less@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-1.1.0.tgz#bdcc76be64c4324d873fbc5cd9fa2e799e4305fa"
+  dependencies:
+    postcss "^5.2.16"
+
+postcss-media-query-parser@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+
+postcss-scss@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.0.tgz#4957013097973dfd5bd9b1ad8a6dc13456a5d1ba"
+  dependencies:
+    postcss "^6.0.1"
+
+postcss-selector-parser@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+"postcss-values-parser@git://github.com/lydell/postcss-values-parser.git#af2c80b2bb558a6e7d61540d97f068f9fa162b38":
+  version "1.3.0"
+  resolved "git://github.com/lydell/postcss-values-parser.git#af2c80b2bb558a6e7d61540d97f068f9fa162b38"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss@^5.2.16:
+  version "5.2.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
+postcss@^6.0.1:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.10.tgz#c311b89734483d87a91a56dc9e53f15f4e6e84e4"
+  dependencies:
+    chalk "^2.1.0"
+    source-map "^0.5.7"
+    supports-color "^4.2.1"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -1376,9 +1607,42 @@ prettier-config-ikatyang@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/prettier-config-ikatyang/-/prettier-config-ikatyang-1.1.1.tgz#9ccab4bc2d441e4c68b58dbe8f1a4e18213c3f2d"
 
-prettier@1.6.1:
+prettier@ikatyang/prettier#50cfbf7:
   version "1.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.6.1.tgz#850f411a3116226193e32ea5acfc21c0f9a76d7d"
+  resolved "https://codeload.github.com/ikatyang/prettier/tar.gz/50cfbf7"
+  dependencies:
+    babel-code-frame "7.0.0-alpha.12"
+    babylon "7.0.0-beta.22"
+    chalk "2.0.1"
+    cosmiconfig "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3"
+    dashify "0.2.2"
+    diff "3.2.0"
+    esutils "2.0.2"
+    flow-parser "0.51.0"
+    get-stream "3.0.0"
+    globby "^6.1.0"
+    graphql "0.10.1"
+    ignore "^3.3.3"
+    jest-validate "20.0.3"
+    minimatch "3.0.4"
+    minimist "1.2.0"
+    parse5 "3.0.2"
+    postcss "^6.0.1"
+    postcss-less "^1.0.0"
+    postcss-media-query-parser "0.2.3"
+    postcss-scss "1.0.0"
+    postcss-selector-parser "2.2.3"
+    postcss-values-parser "git://github.com/lydell/postcss-values-parser.git#af2c80b2bb558a6e7d61540d97f068f9fa162b38"
+    strip-bom "3.0.0"
+    typescript "2.5.1"
+    typescript-eslint-parser "git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567"
+
+pretty-format@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
+  dependencies:
+    ansi-regex "^2.1.1"
+    ansi-styles "^3.0.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -1481,6 +1745,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -1515,6 +1783,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -1543,7 +1815,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
+source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -1583,6 +1855,10 @@ split@^1.0.0:
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
   dependencies:
     through "2"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 standard-version@4.2.0:
   version "4.2.0"
@@ -1629,15 +1905,15 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-bom@3.0.0, strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
-
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -1653,11 +1929,17 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+supports-color@^4.0.0, supports-color@^4.2.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  dependencies:
+    has-flag "^2.0.0"
 
 test-exclude@^4.1.1:
   version "4.1.1"
@@ -1771,6 +2053,17 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567":
+  version "6.0.1"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.3.0"
+
+typescript@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
+
 typescript@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
@@ -1787,6 +2080,10 @@ uglify-js@^2.6:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
 util-deprecate@~1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,9 +1607,9 @@ prettier-config-ikatyang@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/prettier-config-ikatyang/-/prettier-config-ikatyang-1.1.1.tgz#9ccab4bc2d441e4c68b58dbe8f1a4e18213c3f2d"
 
-prettier@ikatyang/prettier#test-deps:
+prettier@ikatyang/prettier#feat/resolve-config-sync:
   version "1.6.1"
-  resolved "https://codeload.github.com/ikatyang/prettier/tar.gz/1cde07cd1c9e8ddb84dbcde2bafd3bcf5741b5aa"
+  resolved "https://codeload.github.com/ikatyang/prettier/tar.gz/687e40a2b37413af8fe4c686e193580640e6c723"
   dependencies:
     babel-code-frame "7.0.0-alpha.12"
     babylon "7.0.0-beta.22"


### PR DESCRIPTION
- [x] wait for https://github.com/prettier/prettier/pull/2722
- [x] backward compatibility
  - uses default options if no `resolveConfig.sync()` or config file not found
- [x] wait for new prettier release
- [x] update prettier version (devDeps + readme)