### PR TITLE
feat: v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ If there is no option provided, it'll try to load [config file](https://prettier
 }
 ```
 
-If you'd like to specify where to find the config file, just put the search path (relative to `process.cwd()`) in the second argument, the following example shows how to use the config file from `<cwd>/configs/.prettierrc`:
+If you'd like to specify which config file to use, just put its path (relative to `process.cwd()`) in the second argument, the following example shows how to load the config file from `<cwd>/configs/.prettierrc`:
 
 ```json
 {
   "extends": ["tslint-plugin-prettier"],
   "rules": {
-    "prettier": [true, "configs"]
+    "prettier": [true, "configs/.prettierrc"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install --save-dev tslint-plugin-prettier prettier
 yarn add --dev tslint-plugin-prettier prettier
 ```
 
-(require `prettier@^1.7.0`)
+(require `prettier@^1.9.0`)
 
 ## Usage
 
@@ -71,38 +71,49 @@ for `tslint@^5.2.0`
 
 ## Options
 
-If there is no option provided, it'll try to load [config file](https://prettier.io/docs/en/configuration.html) if possible, uses Prettier's default option if not found.
+- If there is no option provided, it'll try to load [config file](https://prettier.io/docs/en/configuration.html) and/or `.editorconfig` if possible, uses Prettier's default option if not found.
 
-```json
-{
-  "extends": ["tslint-plugin-prettier"],
-  "rules": {
-    "prettier": true
+  ```json
+  {
+    "extends": ["tslint-plugin-prettier"],
+    "rules": {
+      "prettier": true
+    }
   }
-}
-```
+  ```
 
-If you'd like to specify which config file to use, just put its path (relative to `process.cwd()`) in the second argument, the following example shows how to load the config file from `<cwd>/configs/.prettierrc`:
+  If you don't want to load `.editorconfig`, disable it in the third argument.
 
-```json
-{
-  "extends": ["tslint-plugin-prettier"],
-  "rules": {
-    "prettier": [true, "configs/.prettierrc"]
+  ```json
+  {
+    "extends": ["tslint-plugin-prettier"],
+    "rules": {
+      "prettier": [true, null, { "editorconfig": false }]
+    }
   }
-}
-```
+  ```
 
-If you'd like to specify options manually, just put [Prettier Options](https://prettier.io/docs/en/options.html) in the second argument, for example:
+- If you'd like to specify which config file to use, just put its path (relative to `process.cwd()`) in the second argument, the following example shows how to load the config file from `<cwd>/configs/.prettierrc`:
 
-```json
-{
-  "extends": ["tslint-plugin-prettier"],
-  "rules": {
-    "prettier": [true, { "singleQuote": true }]
+  ```json
+  {
+    "extends": ["tslint-plugin-prettier"],
+    "rules": {
+      "prettier": [true, "configs/.prettierrc"]
+    }
   }
-}
-```
+  ```
+
+- If you'd like to specify options manually, just put [Prettier Options](https://prettier.io/docs/en/options.html) in the second argument, for example:
+
+  ```json
+  {
+    "extends": ["tslint-plugin-prettier"],
+    "rules": {
+      "prettier": [true, { "singleQuote": true }]
+    }
+  }
+  ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 Runs Prettier as a TSLint rule and reports differences as individual TSLint issues.
 
-**NOTE**: This project uses official reporter from [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier).
-
 [Changelog](https://github.com/ikatyang/tslint-plugin-prettier/blob/master/CHANGELOG.md)
 
 ## Sample
@@ -41,11 +39,13 @@ npm install --save-dev tslint-plugin-prettier prettier
 yarn add --dev tslint-plugin-prettier prettier
 ```
 
+(require `prettier@^1.7.0`)
+
 ## Usage
 
 (tslint.json)
 
-for `tslint@5.0.0+`
+for `tslint@^5.0.0`
 
 ```json
 {
@@ -56,7 +56,7 @@ for `tslint@5.0.0+`
 }
 ```
 
-for `tslint@5.2.0+`
+for `tslint@^5.2.0`
 
 ```json
 {
@@ -71,7 +71,7 @@ for `tslint@5.2.0+`
 
 ## Options
 
-If there is no option provided, it'll try to load [config file](https://prettier.io/docs/en/configuration.html) if possible (require `prettier@1.7.0+`), uses Prettier's default option if not found.
+If there is no option provided, it'll try to load [config file](https://prettier.io/docs/en/configuration.html) if possible, uses Prettier's default option if not found.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "3.0.3"
   },
   "peerDependencies": {
-    "prettier": "^1.4.0",
+    "prettier": "^1.7.0",
     "tslint": "^5.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "3.0.3"
   },
   "peerDependencies": {
-    "prettier": "^1.7.0",
+    "prettier": "^1.9.0",
     "tslint": "^5.0.0"
   },
   "engines": {

--- a/src/prettierRule.ts
+++ b/src/prettierRule.ts
@@ -14,14 +14,12 @@ export class Rule extends tslint.Rules.AbstractRule {
 
 class Walker extends tslint.AbstractWalker<any[]> {
   public walk(sourceFile: ts.SourceFile) {
-    const [ruleArgument1] = this.options;
+    const [ruleArgument1, ruleArgument2 = {}] = this.options;
+    const { editorconfig = true } = ruleArgument2;
 
     let options: prettier.Options = {};
 
     switch (typeof ruleArgument1) {
-      case 'object':
-        options = ruleArgument1 as prettier.Options;
-        break;
       case 'string': {
         const configFilePath = path.resolve(
           process.cwd(),
@@ -30,7 +28,7 @@ class Walker extends tslint.AbstractWalker<any[]> {
 
         const resolvedConfig = prettier.resolveConfig.sync(
           sourceFile.fileName,
-          { config: configFilePath },
+          { config: configFilePath, editorconfig },
         );
 
         // istanbul ignore next
@@ -41,8 +39,17 @@ class Walker extends tslint.AbstractWalker<any[]> {
         options = resolvedConfig;
         break;
       }
+      case 'object':
+        if (ruleArgument1) {
+          options = ruleArgument1 as prettier.Options;
+          break;
+        }
+      // falls through for null
       default: {
-        const resolvedConfig = prettier.resolveConfig.sync(sourceFile.fileName);
+        const resolvedConfig = prettier.resolveConfig.sync(
+          sourceFile.fileName,
+          { editorconfig },
+        );
 
         if (resolvedConfig !== null) {
           options = resolvedConfig;

--- a/src/prettierRule.ts
+++ b/src/prettierRule.ts
@@ -23,12 +23,19 @@ class Walker extends tslint.AbstractWalker<any[]> {
         options = ruleArgument1 as prettier.Options;
         break;
       case 'string': {
-        const filePath = path.resolve(process.cwd(), ruleArgument1 as string);
-        const resolvedConfig = prettier.resolveConfig.sync(filePath);
+        const configFilePath = path.resolve(
+          process.cwd(),
+          ruleArgument1 as string,
+        );
+
+        const resolvedConfig = prettier.resolveConfig.sync(
+          sourceFile.fileName,
+          { config: configFilePath },
+        );
 
         // istanbul ignore next
         if (resolvedConfig === null) {
-          throw new Error(`Config file not found: ${filePath}`);
+          throw new Error(`Config file not found: ${configFilePath}`);
         }
 
         options = resolvedConfig;

--- a/tests/prettier/editorconfig/.editorconfig
+++ b/tests/prettier/editorconfig/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_size = 8

--- a/tests/prettier/editorconfig/test.ts.lint
+++ b/tests/prettier/editorconfig/test.ts.lint
@@ -1,0 +1,4 @@
+if (condition) {
+  doSomething();
+  ~              [Insert `······`]
+}

--- a/tests/prettier/editorconfig/tslint.json
+++ b/tests/prettier/editorconfig/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../rules"],
+  "rules": {
+    "prettier": true
+  }
+}

--- a/tests/prettier/no-editorconfig/.editorconfig
+++ b/tests/prettier/no-editorconfig/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_size = 8

--- a/tests/prettier/no-editorconfig/test.ts.lint
+++ b/tests/prettier/no-editorconfig/test.ts.lint
@@ -1,0 +1,3 @@
+if (condition) {
+  doSomething();
+}

--- a/tests/prettier/no-editorconfig/tslint.json
+++ b/tests/prettier/no-editorconfig/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../rules"],
+  "rules": {
+    "prettier": [true, null, { "editorconfig": false }]
+  }
+}

--- a/tests/prettier/specified-config/tslint.json
+++ b/tests/prettier/specified-config/tslint.json
@@ -1,6 +1,6 @@
 {
   "rulesDirectory": ["../../../rules"],
   "rules": {
-    "prettier": [true, "./fixtures/no-semi"]
+    "prettier": [true, "./fixtures/no-semi/.prettierrc"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
     "prettier-config-ikatyang/tslint"
   ],
   "rules": {
-    "max-classes-per-file": false
+    "max-classes-per-file": false,
+    "no-switch-case-fall-through": true
   }
 }


### PR DESCRIPTION
Fixes #255

- require `prettier@1.9.0+`
- specify config file via filepath instead of directory
- load `.editorconfig` by default